### PR TITLE
Windows compatibility

### DIFF
--- a/lib/wp-phptidy.coffee
+++ b/lib/wp-phptidy.coffee
@@ -23,6 +23,6 @@ module.exports =
 				);
 				
 			else
-		  		child_process.exec('php ' + __dirname + '/../vendor/wp-phptidy.php replace ' + filepath)
+		  		child_process.exec(__dirname + '/../vendor/wp-phptidy.php replace ' + filepath)
 
 

--- a/lib/wp-phptidy.coffee
+++ b/lib/wp-phptidy.coffee
@@ -1,4 +1,5 @@
 child_process = require 'child_process'
+os            = require 'os'
 
 module.exports =
 	activate: (state) ->
@@ -12,4 +13,16 @@ module.exports =
 		filepath = file?.path
 
 		if filepath.length
-		  child_process.exec('php ' + __dirname + '/../vendor/wp-phptidy.php replace ' + filepath)
+			if os.type() is 'Windows_NT'
+				child_process.exec('php ' + __dirname + '/../vendor/wp-phptidy.php replace ' + filepath, {}, (error, stdout, stderror) -> 
+					if error?
+						atom.notifications.addError '
+						[WP-PHPTidy] PHP is not installed or there was
+						an error running it.',
+						{dismissable: true}
+				);
+				
+			else
+		  		child_process.exec('php ' + __dirname + '/../vendor/wp-phptidy.php replace ' + filepath)
+
+

--- a/lib/wp-phptidy.coffee
+++ b/lib/wp-phptidy.coffee
@@ -12,4 +12,4 @@ module.exports =
 		filepath = file?.path
 
 		if filepath.length
-		  child_process.exec(__dirname + '/../vendor/wp-phptidy.php replace ' + filepath)
+		  child_process.exec('php ' + __dirname + '/../vendor/wp-phptidy.php replace ' + filepath)

--- a/lib/wp-phptidy.coffee
+++ b/lib/wp-phptidy.coffee
@@ -24,5 +24,3 @@ module.exports =
 				
 			else
 		  		child_process.exec(__dirname + '/../vendor/wp-phptidy.php replace ' + filepath)
-
-


### PR DESCRIPTION
Windows doesn't recognize the shebang at the top of wp-phptidy.php, so I've added an explicit OS check and I prepend PHP to the start of the command if it's Windows_NT. It also reports an error if the command fails (only on Windows, but I guess this could be rewritten to apply to both).
